### PR TITLE
Fix Storyblok preview environment variable names

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git stash push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Storyblok - Use separate tokens for security (matching official guide)
-NEXT_PUBLIC_STORYBLOCK_PREVIEW_ACCESS_TOKEN=your_preview_token_here
-STORYBLOCK_PUBLIC_ACCESS_TOKEN=your_public_token_here
+# Storyblok - Match your actual Vercel environment variables
+NEXT_PUBLIC_STORYBLOK_PREVIEW_TOKEN=your_preview_token_here
+NEXT_PUBLIC_STORYBLOK_API_TOKEN=your_api_token_here
 STORYBLOK_PREVIEW_SECRET=your_secret_key_here

--- a/src/lib/storyblok-client.ts
+++ b/src/lib/storyblok-client.ts
@@ -3,7 +3,7 @@ import { apiPlugin, storyblokInit } from "@storyblok/react/rsc";
 
 export const initStoryblokClient = () => {
   storyblokInit({
-    accessToken: process.env.NEXT_PUBLIC_STORYBLOCK_PREVIEW_ACCESS_TOKEN,
+    accessToken: process.env.NEXT_PUBLIC_STORYBLOK_PREVIEW_TOKEN,
     use: [apiPlugin],
     enableFallbackComponent: true,
   });

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -5,12 +5,34 @@ export const storyblokComponents = COMPONENTS;
 
 export const getStoryblokApi = (preview = false) => {
   const accessToken = preview
-    ? process.env.NEXT_PUBLIC_STORYBLOCK_PREVIEW_ACCESS_TOKEN
-    : process.env.STORYBLOCK_PUBLIC_ACCESS_TOKEN;
-  return storyblokInit({
-    accessToken,
-    use: [apiPlugin],
-    components: storyblokComponents,
-    enableFallbackComponent: true,
-  })();
+    ? process.env.NEXT_PUBLIC_STORYBLOK_PREVIEW_TOKEN
+    : process.env.NEXT_PUBLIC_STORYBLOK_API_TOKEN;
+    
+  console.log("getStoryblokApi called with preview:", preview);
+  console.log("Access token:", accessToken ? "exists" : "missing");
+  
+  if (!accessToken) {
+    console.error("No access token available for preview:", preview);
+    return null;
+  }
+  
+  try {
+    const result = storyblokInit({
+      accessToken,
+      use: [apiPlugin],
+      components: storyblokComponents,
+      enableFallbackComponent: true,
+    });
+    
+    console.log("storyblokInit result:", result);
+    
+    // Try calling it as a function
+    const api = result();
+    console.log("API after calling result():", api);
+    
+    return api;
+  } catch (error) {
+    console.error("Error initializing Storyblok:", error);
+    return null;
+  }
 };


### PR DESCRIPTION
## Summary
- Fix environment variable naming mismatch causing preview failures
- Update STORYBLOCK → STORYBLOK to match actual Vercel configuration  
- Add debugging logs for troubleshooting preview API issues

## Problem
The Storyblok preview was failing with "Cannot read properties of undefined (reading 'getStory')" because:
- Code was looking for `NEXT_PUBLIC_STORYBLOCK_PREVIEW_ACCESS_TOKEN`
- But Vercel had `NEXT_PUBLIC_STORYBLOK_PREVIEW_TOKEN` 
- Environment variable mismatch prevented SDK initialization

## Changes
- Update `src/lib/storyblok.ts` to use correct env var names
- Update `src/lib/storyblok-client.ts` to match 
- Update `.env.example` with correct variable names
- Add debugging logs to troubleshoot initialization issues

## Test Plan
- [ ] Deploy changes to preview environment
- [ ] Verify environment variables match code expectations
- [ ] Test preview URL: `/api/preview?secret=SECRET&slug=blog/post-slug`
- [ ] Verify Visual Editor loads correctly
- [ ] Test draft content display in preview routes